### PR TITLE
Fix invalid lines in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,14 +3,7 @@ version=1.0.1
 author=Wh1teRabbitHU
 maintainer=Tamas Ruszka
 sentence=This adapter can read and write AT28C64 and AT28C256 EEPROM chips using Arudino Mega. Creating converter PCB for this task recommended
-paragraph=You can use the code in the src/main.cpp file directly to control your adapter via Serial port or just using the EEPROMAdapter class in a different way.\
-\
-EEPROMAdapter\
-\
-This is the low level adapter, which can read and write data directly from/to the given address. You can run these operations one by one. If you need automatisation or more controlled handling, please check the EEPROMSerial class, which allows you to control your commands via serial port. (or any stream compatible way)\
-\
-EEPROMSerial\
-This is a helper function, which is using the EEPROMAdapter to read or write to your memory via serial port.
+paragraph=You can use the code in the src/main.cpp file directly to control your adapter via Serial port or just using the EEPROMAdapter class in a different way.<br /><br />EEPROMAdapter<br />This is the low level adapter, which can read and write data directly from/to the given address. You can run these operations one by one. If you need automatisation or more controlled handling, please check the EEPROMSerial class, which allows you to control your commands via serial port. (or any stream compatible way)<br /><br />EEPROMSerial<br />This is a helper function, which is using the EEPROMAdapter to read or write to your memory via serial port.
 category=Data Storage
 url=https://github.com/Wh1teRabbitHU/EEPROMAdapter
 architectures=*


### PR DESCRIPTION
Each line in library.properties must either contain an '=', start with a '#', or be whitespace. Installation of a library with an invalid line will cause compilation of any code (even if it doesn't `#include` the library) to fail:
```
loading libs from E:\arduino\libraries: loading library from E:\arduino\libraries\EEPROMAdapter: loading library.properties: Error reading file (E:\arduino\libraries\EEPROMAdapter\library.properties:6): Invalid line format, should be 'key=value'
```

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format